### PR TITLE
Removed ref to success_purchase_message unused string

### DIFF
--- a/app/src/main/res/layouts/other_layouts/layout/drawer_header.xml
+++ b/app/src/main/res/layouts/other_layouts/layout/drawer_header.xml
@@ -32,7 +32,6 @@
             android:layout_alignBottom="@+id/navAvatarLayout"
             android:layout_alignStart="@+id/navAvatarLayout"
             android:layout_marginStart="@dimen/spacing_large"
-            android:contentDescription="@string/success_purchase_message"
             android:src="@drawable/ic_heart_full"
             android:visibility="gone"
             tools:visibility="visible"/>


### PR DESCRIPTION
We no longer need this string in the liberated fork. Does it still compile without it?